### PR TITLE
Add margins config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ class PdfAttachment extends AttachPdf
 
 Contributions and discussions are always welcome, no matter how large or small. If you happen to find an issue, please open up a Github issue or do a PR if you can.
 
-[^1]: The addon required Browserhot for the PDF attachment to work out of the box. Please note that the addon will not install Browsershot for you as you might have already installed some version of it. Please install Browsershot directly into your project.
+[^1]: The addon requires Browserhot for the PDF attachment to work out of the box. Please note that the addon will not install Browsershot for you as you might have already installed some version of it. Please install Browsershot directly into your project.
 [^2]: Refer to the offical [Laravel documentation](https://laravel.com/docs/mail#attachments) on how to create attachments in various ways.

--- a/config/statamic-formattach.php
+++ b/config/statamic-formattach.php
@@ -38,6 +38,17 @@ return [
         'A6' => ['105mm', '148mm'],
     ],
 
+    /**
+     * The margins applied to PDF pages.
+     */
+    'margins' => [
+        'top' => 10,
+        'right' => 15,
+        'bottom' => 15,
+        'left' => 10,
+        'unit' => 'mm',
+    ],
+
     'forms' => [
         'form_handle' => [
             // \SchantlDev\Statamic\FormAttach\Attachments\AttachPdf::class,

--- a/resources/views/pdf_attachment.antlers.html
+++ b/resources/views/pdf_attachment.antlers.html
@@ -18,6 +18,13 @@
                 padding: 0;
             }
 
+            .preview-margins {
+                padding-top: {{ config:statamic-formattach:margins:top ?? 10 }}{{ config:statamic-formattach:margins:unit ?? 'mm' }};
+                padding-right: {{ config:statamic-formattach:margins:right ?? 15 }}{{ config:statamic-formattach:margins:unit ?? 'mm' }};
+                padding-bottom: {{ config:statamic-formattach:margins:bottom ?? 10 }}{{ config:statamic-formattach:margins:unit ?? 'mm' }};
+                padding-left: {{ config:statamic-formattach:margins:left ?? 15 }}{{ config:statamic-formattach:margins:unit ?? 'mm' }};
+            }
+
             {{ partial src="statamic-formattach::pdf_styles" }}
         </style>
     </head>
@@ -25,47 +32,45 @@
         {{ if preview }}
             <div class="mx-auto w-[--page-width] overflow-y-auto my-20">
         {{ /if }}
-        <section class="bg-white flex flex-col w-full h-screen shrink-0 overflow-hidden relative {{ preview ?= 'border mt-5 max-h-[--page-height]' }}">
-            <div class="absolute inset-0" style="padding: 5mm 20mm;">
-                <div class="w-full flex justify-between items-end pb-4">
-                    <h1 class="text-2xl font-bold">{{ subject }}</h1>
-                    {{ if logo }}
-                        <div class="ml-auto">
-                            {{? $img = base64_encode(file_get_contents($logo)) ?}}
-                            <img src="data:image/png;base64,{{ $img }}" alt="Logo" class="h-24 ml-16">
+        <section class="bg-white flex flex-col w-full shrink-0 relative {{ preview ? 'border mt-5 preview-margins' : 'h-screen' }}">
+            <div class="w-full flex justify-between items-end pb-4">
+                <h1 class="text-2xl font-bold">{{ subject }}</h1>
+                {{ if logo }}
+                    <div class="ml-auto">
+                        {{? $img = base64_encode(file_get_contents($logo)) ?}}
+                        <img src="data:image/png;base64,{{ $img }}" alt="Logo" class="h-24 ml-16">
+                    </div>
+                {{ /if }}
+            </div>
+            <div class="grid grid-cols-12 gap-6 text-xs">
+                {{ submission:fields }}
+                    {{ if value && {config['visibility']} !== 'hidden' }}
+                        {{? 
+                            $width = match($blueprint[$handle]['width']) {
+                                25 => 'col-span-3',
+                                33 => 'col-span-4',
+                                50 => 'col-span-6',
+                                66 => 'col-span-8',
+                                75 => 'col-span-9',
+                                default => 'col-span-12'
+                            };
+                        ?}}
+                        <div class="{{ width }}">
+                            <label class="font-bold uppercase text-[.8em]" for="{{ handle }}">{{ config['display'] }}</label>
+                            {{ if (value | is_array) }}
+                                <p>
+                                    {{ value }}
+                                        <span>
+                                            {{ (label ?? value) | nl2br }}
+                                        </span>{{ !last ?= '<br>' }}
+                                    {{ /value }}
+                                </p>
+                            {{ else }}
+                                <p id="{{ handle }}">{{ (value:label ?? value) | nl2br }}</p>
+                            {{ /if }}
                         </div>
                     {{ /if }}
-                </div>
-                <div class="grid grid-cols-12 gap-6 text-xs">
-                    {{ submission:fields }}
-                        {{ if value && {config['visibility']} !== 'hidden' }}
-                            {{? 
-                                $width = match($blueprint[$handle]['width']) {
-                                    25 => 'col-span-3',
-                                    33 => 'col-span-4',
-                                    50 => 'col-span-6',
-                                    66 => 'col-span-8',
-                                    75 => 'col-span-9',
-                                    default => 'col-span-12'
-                                };
-                            ?}}
-                            <div class="{{ width }}">
-                                <label class="font-bold uppercase text-[.8em]" for="{{ handle }}">{{ config['display'] }}</label>
-                                {{ if (value | is_array) }}
-                                    <p>
-                                        {{ value }}
-                                            <span>
-                                                {{ (label ?? value) | nl2br }}
-                                            </span>{{ !last ?= '<br>' }}
-                                        {{ /value }}
-                                    </p>
-                                {{ else }}
-                                    <p id="{{ handle }}">{{ (value:label ?? value) | nl2br }}</p>
-                                {{ /if }}
-                            </div>
-                        {{ /if }}
-                    {{ /submission:fields }}
-                </div>
+                {{ /submission:fields }}
             </div>
         </section>
         {{ if preview }}

--- a/resources/views/pdf_styles.css
+++ b/resources/views/pdf_styles.css
@@ -531,8 +531,8 @@ video {
 .h-screen {
   height: 100vh;
 }
-.max-h-\[--page-height\] {
-  max-height: var(--page-height);
+.min-h-\[--page-height\] {
+  min-height: var(--page-height);
 }
 .w-\[--page-width\] {
   width: var(--page-width);

--- a/src/Attachments/AttachPdf.php
+++ b/src/Attachments/AttachPdf.php
@@ -41,6 +41,7 @@ class AttachPdf extends FormAttachment
             'blueprint' => $this->submissionHelper->blueprintFields(),
             'page_size' => config('statamic-formattach.format_sizes.'.$this->size),
             'preview' => $preview,
+            'config' => config()->all(),
         ])->render();
     }
 
@@ -49,6 +50,13 @@ class AttachPdf extends FormAttachment
         return
             \Spatie\Browsershot\Browsershot::html($this->view())
                 ->format($this->size)
+                ->margins(
+                    top: config('statamic-formattach.margins.top', null),
+                    right: config('statamic-formattach.margins.right', null),
+                    bottom: config('statamic-formattach.margins.bottom', null),
+                    left: config('statamic-formattach.margins.left', null),
+                    unit: config('statamic-formattach.margins.unit', null),
+                )
                 ->pdf();
     }
 }


### PR DESCRIPTION
This PR allows to set margins for a page.

Previously, if the generated content was longer than the page, it content would have been cut off. This PR allows to set margins for a PDF page and content to not be cut off - resulting in multiple pages if needed.

Feel free to add the following to the addons config file:
```php
/**
 * The margins applied to PDF pages.
 */
'margins' => [
    'top' => 0,
    'right' => 15,
    'bottom' => 5,
    'left' => 10,
    'unit' => 'mm',
],
```